### PR TITLE
Fix loading Flux Dev transformers from_single_file

### DIFF
--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -605,7 +605,10 @@ def infer_diffusers_model_type(checkpoint):
         if any(
             g in checkpoint for g in ["guidance_in.in_layer.bias", "model.diffusion_model.guidance_in.in_layer.bias"]
         ):
-            if checkpoint["img_in.weight"].shape[1] == 384:
+            if "img_in.weight" not in checkpoint:
+                model_type = "flux-dev"
+
+            elif checkpoint["img_in.weight"].shape[1] == 384:
                 model_type = "flux-fill"
 
             elif checkpoint["img_in.weight"].shape[1] == 128:


### PR DESCRIPTION
Description and reproducer in:
https://github.com/huggingface/diffusers/issues/10540


Please check the added condition before you merge.
This code works, but I am not sure what the key in question does. It seems to be absent in transformer-only Flux.Dev files. But it could also be absent in transformer-only Flux Fill files? I don't know. In that case, a different condition to tell the two apart is needed.

Fixes #10540 (issue)




## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@DN6

